### PR TITLE
Add ability to release application for Debian Linux platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ application file.
 
 ### Linux
 #### Ubuntu / Debian
-TBD
-
-#### RHEL / CentOS / Fedora
-TBD
+1. Use your system's software manager/installer
+(or simply double-click, in most desktop distros) to install the versioned
+`roe-sizer-vx.y.z-linux-x64.deb` Debian package.
+2. If you're using Linux, you know how to run the software that you install.
+There are simply too many distros and desktop environments for me to list the
+myriad ways to run an application. Look for the Roe-Sizer icon!
 
 ## Usage
 1. Paste in *input* directory. This should be a folder containing the images that need to be processed.

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "roe-sizer",
   "productName": "Roe-Sizer",
   "description": "Handy image batch resizer, designed with LuLaRoe consultants in mind.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": "Brian Shef <brianshef@gmail.com>",
   "copyright": "© 2016, Brian Shef",
   "main": "background.js",

--- a/resources/linux/app.desktop
+++ b/resources/linux/app.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version={{version}}
 Type=Application
 Encoding=UTF-8
 Name={{productName}}


### PR DESCRIPTION
This pull request adds the following changes:
- Verified ability to release the application for Debian Linux distributions
- Verified local testing of Roe-Sizer app in Ubuntu 14.04 LTS
